### PR TITLE
ci: add GitHub Actions workflow for build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,22 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            zig-arch: x86_64-linux
+            zig-sha256: 02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
+          - os: macos-latest
+            zig-arch: aarch64-macos
+            zig-sha256: 3cc2bab367e185cdfb27501c4b30b1b0653c28d9f73df8dc91488e66ece5fa6b
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
@@ -16,34 +29,20 @@ jobs:
 
       - name: Install Zig 0.15.2
         run: |
-          ZIG_URL="https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz"
+          ZIG_VERSION="0.15.2"
+          ZIG_ARCH="${{ matrix.zig-arch }}"
+          ZIG_SHA256="${{ matrix.zig-sha256 }}"
+          ZIG_TARBALL="zig-${ZIG_ARCH}-${ZIG_VERSION}.tar.xz"
+          ZIG_URL="https://ziglang.org/download/${ZIG_VERSION}/${ZIG_TARBALL}"
+
           echo "Downloading: $ZIG_URL"
-          curl -sL "$ZIG_URL" | tar xJ
-          ZIG_DIR=$(ls -d zig-x86_64-linux-*)
-          echo "$PWD/$ZIG_DIR" >> $GITHUB_PATH
+          curl -fL -o "$ZIG_TARBALL" "$ZIG_URL"
 
-      - name: Check Zig version
-        run: zig version
+          echo "Verifying checksum..."
+          echo "${ZIG_SHA256}  ${ZIG_TARBALL}" | shasum -a 256 -c -
 
-      - name: Build
-        run: zig build
-
-      - name: Test
-        run: zig build test
-
-  build-macos:
-    runs-on: macos-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Zig 0.15.2
-        run: |
-          ZIG_URL="https://ziglang.org/download/0.15.2/zig-aarch64-macos-0.15.2.tar.xz"
-          echo "Downloading: $ZIG_URL"
-          curl -sL "$ZIG_URL" | tar xJ
-          ZIG_DIR=$(ls -d zig-aarch64-macos-*)
+          tar xJf "$ZIG_TARBALL"
+          ZIG_DIR=$(ls -d zig-${ZIG_ARCH}-*)
           echo "$PWD/$ZIG_DIR" >> $GITHUB_PATH
 
       - name: Check Zig version


### PR DESCRIPTION
## Summary

- Add CI workflow that runs on push to main and PRs
- Build and test on Ubuntu and macOS
- Uses Zig 0.15.2 (same as local development)

## Jobs

| Job | OS | Steps |
|-----|-----|-------|
| build-and-test | Ubuntu | Build, Test |
| build-macos | macOS | Build, Test |

---
🤖 Generated with Claude Code