### PR TITLE
docs: simplify tree view description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ TUI file explorer with Vim keybindings, written in Zig.
 
 ## Features
 
-- VSCode-like tree view with expand/collapse
+- Tree view with expand/collapse
 - Vim-native navigation (hjkl, gg/G)
 - Incremental search with highlighting
 - File preview with line numbers


### PR DESCRIPTION
## Summary

Remove "VSCode-like" from tree view description - it's just a standard tree view.

## Change

```diff
-- VSCode-like tree view with expand/collapse
+- Tree view with expand/collapse
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)